### PR TITLE
🧹 chore: Don't run tests in GH ci, use Dagger cloud

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,23 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run tests via Dagger
-        uses: dagger/dagger-for-github@v8.2.0
-        env:
-          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-        with:
-          verb: call
-          args: test
-          version: ${{ env.DAGGER_VERSION }}
-
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -94,10 +94,10 @@ jobs:
             Commit: ${{ github.sha }}
 
             **Download:**
-            - Linux AMD64: `curl -LO https://download.tapes.dev/nightly/linux/amd64/tapes`
-            - Linux ARM64: `curl -LO https://download.tapes.dev/nightly/linux/arm64/tapes`
-            - macOS AMD64: `curl -LO https://download.tapes.dev/nightly/darwin/amd64/tapes`
-            - macOS ARM64: `curl -LO https://download.tapes.dev/nightly/darwin/arm64/tapes`
+            - Linux AMD64: `curl -LO https://masterblaster.stereos.ai/nightly/linux/amd64/mb`
+            - Linux ARM64: `curl -LO https://masterblaster.stereos.ai/nightly/linux/arm64/mb`
+            - macOS AMD64: `curl -LO https://masterblaster.stereos.ai/nightly/darwin/amd64/mb`
+            - macOS ARM64: `curl -LO https://masterblaster.stereos.ai/nightly/darwin/arm64/mb`
           prerelease: true
           allowUpdates: true
           removeArtifacts: true


### PR DESCRIPTION
* 🧹 fixes the tests running in GH CI, instead uses dagger cloud
* 🧹 fixes the download links in nightly release