### PR TITLE
🔧  fix: Fix releases for latest and nightly

### DIFF
--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -29,15 +29,15 @@ func (m *Masterblaster) ReleaseLatest(
 
 	// Bucket secret access key
 	secretAccessKey *dagger.Secret,
-) (string, error) {
+) (*dagger.Directory, error) {
 	artifacts := m.BuildRelease(ctx, version, commit)
 
 	uploader := dag.Bucketuploader(endpoint, bucket, accessKeyId, secretAccessKey)
 	if err := uploader.UploadLatest(ctx, artifacts, version); err != nil {
-		return "", fmt.Errorf("failed to upload latest release: %w", err)
+		return nil, fmt.Errorf("failed to upload latest release: %w", err)
 	}
 
-	return fmt.Sprintf("released %s and updated latest", version), nil
+	return artifacts, nil
 }
 
 // ReleaseNightly builds nightly release binaries and uploads them to the
@@ -59,15 +59,15 @@ func (m *Masterblaster) ReleaseNightly(
 
 	// Bucket secret access key
 	secretAccessKey *dagger.Secret,
-) (string, error) {
+) (*dagger.Directory, error) {
 	artifacts := m.BuildRelease(ctx, "nightly", commit)
 
 	uploader := dag.Bucketuploader(endpoint, bucket, accessKeyId, secretAccessKey)
 	if err := uploader.UploadNightly(ctx, artifacts); err != nil {
-		return "", fmt.Errorf("failed to upload nightly release: %w", err)
+		return nil, fmt.Errorf("failed to upload nightly release: %w", err)
 	}
 
-	return "released nightly", nil
+	return artifacts, nil
 }
 
 // UploadInstallScript uploads the install.sh script to the root of the bucket.

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Build upload nightly release artifacts
         run: |
           dagger call \
-            nightly \
+            release-nightly \
               --commit="${{ github.sha }}" \
               --endpoint=env://BUCKET_ENDPOINT \
               --bucket=env://BUCKET_NAME \
@@ -106,24 +106,12 @@ jobs:
 
       - name: Upload artifacts to release
         run: |
-          mkdir -p dist
-          for file in $(find build -type f); do
-            rel_path="${file#build/}"
-            os=$(dirname "$rel_path" | cut -d'/' -f1)
-            arch=$(dirname "$rel_path" | cut -d'/' -f2)
-            filename=$(basename "$file")
-
-            if [[ "$filename" == *.sha256 ]]; then
-              base="${filename%.sha256}"
-              new_name="${base}-${os}-${arch}.sha256"
-            else
-              new_name="${filename}-${os}-${arch}"
-            fi
-
-            cp "$file" "dist/$new_name"
-          done
-
-          gh release upload "nightly" dist/*
+          dagger call \
+              --token=env:GH_TOKEN \
+              --repo=papercompute/masterblaster \ 
+            flatten \
+              --build=./build
+            upload \
+              --tag="nightly"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,23 +43,12 @@ jobs:
 
       - name: Upload artifacts to release
         run: |
-          mkdir -p dist
-          for file in $(find build -type f); do
-            rel_path="${file#build/}"
-            os=$(dirname "$rel_path" | cut -d'/' -f1)
-            arch=$(dirname "$rel_path" | cut -d'/' -f2)
-            filename=$(basename "$file")
-
-            if [[ "$filename" == *.sha256 ]]; then
-              base="${filename%.sha256}"
-              new_name="${base}-${os}-${arch}.sha256"
-            else
-              new_name="${filename}-${os}-${arch}"
-            fi
-
-            cp "$file" "dist/$new_name"
-          done
-
-          gh release upload "${{ github.event.release.tag_name }}" dist/*
+          dagger call \
+              --token=env:GH_TOKEN \
+              --repo=papercompute/masterblaster \ 
+            flatten \
+              --build=./build
+            upload \
+              --tag="${{ github.event.release.tag_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dagger.json
+++ b/dagger.json
@@ -21,6 +21,11 @@
       "name": "checksumer",
       "source": "github.com/papercomputeco/daggerverse/checksum@main",
       "pin": "fb6639c78909eaa96dcd3a31faad535fa162b01a"
+    },
+    {
+      "name": "ghrelease",
+      "source": "github.com/papercomputeco/daggerverse/ghrelease@main",
+      "pin": "5b6d08d8437722295b6cff1f51853297bf04a737"
     }
   ],
   "source": ".dagger"

--- a/makefile
+++ b/makefile
@@ -52,6 +52,16 @@ release: ## Builds and releases mb artifacts
 			--access-key-id=env://BUCKET_ACCESS_KEY_ID \
 			--secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
 
+.PHONY: nightly
+nightly: ## Builds and releases mb artifacts with the nightly tag
+	dagger call \
+		release-nightly \
+			--commit=${COMMIT} \
+			--endpoint=env://BUCKET_ENDPOINT \
+			--bucket=env://BUCKET_NAME \
+			--access-key-id=env://BUCKET_ACCESS_KEY_ID \
+			--secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
+
 check:
 	dagger check
 


### PR DESCRIPTION
* 🔧 Release dagger module now returns a `*dagger.Directory` so we can `--export` the artifacts for GitHub action release upload
* ✨ Adds the new `github.com/papercomputeco/daggerverse/ghrelease` which flattens files and uploads them to github release