### PR TITLE
🔧 fix: Use -m dagger module for papercomputeco daggerverse module

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload artifacts to release
         run: |
-          dagger call \
+          dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
               --repo=papercompute/masterblaster \ 
             flatten \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload artifacts to release
         run: |
-          dagger call \
+          dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
               --repo=papercompute/masterblaster \ 
             flatten \


### PR DESCRIPTION
* 🔧 Fixes using `-m` for our daggerverse modules: this had resulted in the `token` argument not being found: https://github.com/papercomputeco/masterblaster/actions/runs/22142333475/job/64009699660