### PR TITLE
🔧 fix: Trailing space after slash

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -108,7 +108,7 @@ jobs:
         run: |
           dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
-              --repo=papercompute/masterblaster \ 
+              --repo=papercompute/masterblaster \
             flatten \
               --build=./build
             upload \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
-              --repo=papercompute/masterblaster \ 
+              --repo=papercompute/masterblaster \
             flatten \
               --build=./build
             upload \


### PR DESCRIPTION
* 🔧 Fixes trailing slash after `\`  in dagger calls