### PR TITLE
🔧 fix: Correctly chain release into "upload" with slash

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -110,8 +110,9 @@ jobs:
               --token=env:GH_TOKEN \
               --repo=papercompute/masterblaster \
             flatten \
-              --build=./build
+              --build=./build \
             upload \
               --tag="nightly"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,9 @@ jobs:
               --token=env:GH_TOKEN \
               --repo=papercompute/masterblaster \
             flatten \
-              --build=./build
+              --build=./build \
             upload \
               --tag="${{ github.event.release.tag_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
* 🔧 fixes trailing slash problems (again 🤦🏼) for chaining correctly into the `upload` dagger call
* 🧹 Adds dagger cloud token