### PR TITLE
🔧 fix: Use right repo names in dagger call for github upload

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -108,7 +108,7 @@ jobs:
         run: |
           dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
-              --repo=papercompute/masterblaster \
+              --repo=papercomputeco/masterblaster \
               --assets=./build \
             with-flatten \
             with-tag --tag "nightly" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
               --token=env:GH_TOKEN \
-              --repo=papercompute/masterblaster \
+              --repo=papercomputeco/masterblaster \
               --assets=./build \
             with-flatten \
             with-tag --tag="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
* 🔧 Correctly use `papercomputeco/masterblaster` for the repo name to upload release assets