### PR TITLE
🔧 fix: backslash after `with-tag` in dagger release upload flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
               --repo=papercomputeco/masterblaster \
               --assets=./build \
             with-flatten \
-            with-tag --tag="${{ github.event.release.tag_name }}"
+            with-tag --tag="${{ github.event.release.tag_name }}" \
             upload
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* 🔧 The backslash strikes again ... we needed a trailing backslash to get `upload` to chain after `with-tag`