### PR TITLE
🧹 chore: Adds colima to CI for dagger to run

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -119,6 +119,12 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 build/darwin/arm64/mb > build/darwin/arm64/mb.sha256
 
+      - name: Setup container runtime on macOS for Dagger
+        id: setup-docker
+        uses: douglascamata/setup-docker-macos-action@v1.0.1
+        with:
+          colima: v0.10.0
+
       - name: Install Dagger
         uses: dagger/dagger-for-github@v8.2.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,12 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 build/darwin/arm64/mb > build/darwin/arm64/mb.sha256
 
+      - name: Setup container runtime on macOS for Dagger
+        id: setup-docker
+        uses: douglascamata/setup-docker-macos-action@v1.0.1
+        with:
+          colima: v0.10.0
+
       - name: Install Dagger
         uses: dagger/dagger-for-github@v8.2.0
         with:


### PR DESCRIPTION
* 🧹 Fixes needing a container runtime on mac runners (which apparently GitHub doesn't pre-install) for Dagger to run