### PR TITLE
🔧 fix: brings back apple-build make target for CI

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,13 +28,27 @@ build-local: ## Builds local artifacts with local toolchain
 	@mkdir -p ./build/local
 	go build -ldflags "$(LDFLAGS)" -o ./build/local/$(BIN_NAME) .
 
+.PHONY: apple-build
+apple-build: ## Apple: builds darwin/arm64 binary with codesign
+	$(call print-target)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "Error: apple-build requires macOS (got $$(uname -s))"; \
+		exit 1; \
+	fi
+	@mkdir -p ./build/darwin/arm64
+	go build -ldflags "$(LDFLAGS)" -o ./build/darwin/arm64/$(BIN_NAME) .
+	codesign --entitlements vz.entitlements -s - ./build/darwin/arm64/$(BIN_NAME)
+
 .PHONY: apple-install
 apple-install: build-local ## Apple: builds, installs to GOBIN, and codesigns binary
 	$(call print-target)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "Error: apple-install requires macOS (got $$(uname -s))"; \
+		exit 1; \
+	fi
 	rm -f $(shell go env GOBIN)/$(BIN_NAME)
 	cp ./build/local/$(BIN_NAME) $(shell go env GOBIN)
 	codesign --entitlements vz.entitlements -s - $(shell go env GOBIN)/$(BIN_NAME)
-	$(call apple-codesign)
 
 .PHONY: upload-darwin-artifacts
 upload-darwin-artifacts: ## Uploads the install script


### PR DESCRIPTION
* 🔧 brings back `apple-build` make target for CI: https://github.com/papercomputeco/masterblaster/actions/runs/22423463279

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/masterblaster/28?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->