### PR TITLE
🔧 fix: Apple raw disc resize now works with fsync

### DIFF
--- a/pkg/vm/applevirt.go
+++ b/pkg/vm/applevirt.go
@@ -390,9 +390,17 @@ func (a *AppleVirtBackend) buildVMConfig(
 	}
 
 	// --- Disk (raw only) ---
-	diskAttachment, err := vz.NewDiskImageStorageDeviceAttachment(
+	// Use cached + fsync mode to ensure guest flush/sync operations are
+	// honored by the Virtualization.framework. Without explicit fsync mode,
+	// the framework may use DiskImageSynchronizationModeNone which silently
+	// drops guest sync calls. This causes ext4 metadata corruption during
+	// boot-time operations like growpart + resize2fs that rely on write
+	// ordering and fsync for journal/checksum consistency.
+	diskAttachment, err := vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(
 		inst.DiskPath(),
 		false, // read-write
+		vz.DiskImageCachingModeCached,
+		vz.DiskImageSynchronizationModeFsync,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating disk attachment for %s: %w", inst.DiskPath(), err)


### PR DESCRIPTION
🔧 fix issue with disc corruption errors during ext4-fs mount/grow since using the non-sync `vz` API could select `DiskImageSynchronizationModeNone` leading to `dmesg` errors like:

```
EXT4-fs error (device vda2): ext4_lookup:1787: inode #147617: comm ls: iget: checksum invalid
EXT4-fs error (device vda2): htree_dirblock_to_tree:1077: inode #195442: block 116189:
    comm exe: bad entry in directory: rec_len is smaller than minimal
```

`vz.NewDiskImageStorageDeviceAttachment()` is the macOS 11 API which doesn't support disk sync mode.

With this fix:

```
sudo dmesg | grep -i ext4
[    2.008609] EXT4-fs (vda2): mounted filesystem f222513b-ded1-49fa-b591-20ce86a2fe7f r/w with ordered data mode. Quota mode: none.
[    3.558817] EXT4-fs (vda2): re-mounted f222513b-ded1-49fa-b591-20ce86a2fe7f.
[    3.989876] EXT4-fs (vda2): resizing filesystem from 1084672 to 5177083 blocks
[    4.015150] EXT4-fs (vda2): resized filesystem to 5177083
```

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/masterblaster/32?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->