### PR TITLE
🔧 fix: Release using new dagger ghrelease "with" constructors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,9 +129,9 @@ jobs:
       - name: Upload all artifacts to GitHub release
         run: |
           dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
-              --token=env:GH_TOKEN \
-              --repo=papercomputeco/masterblaster \
-              --assets=./build \
+              --token=env://GH_TOKEN \
+            with-repo --repo="${{ github.repository }}" \
+            with-assets --assets=./build \
             with-flatten \
             with-tag --tag="${{ github.event.release.tag_name }}" \
             upload


### PR DESCRIPTION
Fixes the release workflow using the "with" constructors: https://github.com/papercomputeco/masterblaster/actions/runs/23383305764/job/68026210569