### PR TITLE
🔧 fix: bump dagger v0.20.6 → v0.20.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   create-release:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   check:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   build-linux:

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "masterblaster",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   },


### PR DESCRIPTION
## Summary

- The release pipeline has been failing because the engine pinned in `dagger.json` (v0.20.6) and the CLI installed by `dagger-for-github` no longer round-trip cleanly with the current daggerverse modules. The version handshake fails before `dagger call` reaches user code.
- Bumps `engineVersion` in `dagger.json` and `DAGGER_VERSION` in all workflows to v0.20.8, matching the rest of the org repos (e.g. `paper` PR #40) that have already moved.

Refs PCC-543

## Test plan

- [ ] CI workflow passes on this PR
- [ ] Release / cut-release workflows succeed on the next tag push