### PR TITLE
🔧 fix: reap the vmhost child so mb down is fast

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -404,10 +404,18 @@ func (d *Daemon) spawnVMHost(_ context.Context, mvm *managedVM, backend string) 
 		return fmt.Errorf("spawning vmhost: %w", err)
 	}
 
-	// Release the process so the daemon doesn't wait on it
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("releasing vmhost process: %w", err)
-	}
+	// Reap the child once it exits. vmhost runs in its own session (Setsid), so
+	// it survives daemon exit and keeps the VM alive across a daemon restart —
+	// but while this daemon is alive it remains the OS parent and must wait() on
+	// it. Without this, an exited vmhost lingers as a zombie and processAlive()
+	// (kill -0) still reports it as running, so `mb down` blocks for its full
+	// 45s timeout even though the VM stopped in ~1s. If the daemon exits first,
+	// init inherits and reaps vmhost instead.
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			d.logger.Printf("vmhost for %q exited: %v", inst.Name, err)
+		}
+	}()
 
 	// Poll vmhost.sock until it responds (same pattern as ensureDaemon)
 	client := vmhost.NewClient(inst.VMHostSocketPath())


### PR DESCRIPTION
## Summary

`mb down` took ~45s even though the guest powered off in ~1s. The daemon spawns
each `vmhost` with `Setsid` and then `cmd.Process.Release()`, never `wait()`ing
on it — so when `vmhost` exits it becomes a **zombie** of the daemon, and the
`mb down` wait loop checks liveness with `processAlive` (`kill -0`), which reports
a zombie as alive. The loop then blocked for its full 45s ceiling.

Fix: reap the child with `go cmd.Wait()` instead of releasing it. `vmhost` still
runs in its own session, so it survives daemon exit and a restart inherits it via
init; while this daemon is alive it is the OS parent and must `wait()` to avoid
the zombie. With the PID reaped promptly, `mb down` returns in ~1s.

## Test plan

- [x] `gofmt` / `go vet` / `golangci-lint` clean (0 issues)
- [x] Verified end to end with the `applevirt` backend: `mb up` then `mb down`
      drops from ~45s to ~1s; confirmed no lingering `<defunct>` vmhost
- [x] `vmhost` still survives a daemon restart (Setsid; reattached on restart)

Part of PCC-777.
