### PR TITLE
chore: bump Dagger to 0.21.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Linux binaries via Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         env:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,14 +21,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+
       - name: Build Linux binaries via Dagger
-        uses: dagger/dagger-for-github@v8.4.1
         env:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-        with:
-          verb: call
-          args: build export --path=./build
-          version: ${{ env.DAGGER_VERSION }}
+        run: nix develop --command dagger call build export --path=./build
 
       - name: Upload linux amd64 binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 jobs:
   create-release:
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.PAPER_COMPUTE_CO_BOT_PRIVATE_KEY }}
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -6,9 +6,6 @@ on:
 permissions:
   contents: write
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 jobs:
   create-release:
     name: Cut New GitHub Release
@@ -27,14 +24,15 @@ jobs:
           app-id: ${{ secrets.PAPER_COMPUTE_CO_BOT_APP_ID }}
           private-key: ${{ secrets.PAPER_COMPUTE_CO_BOT_PRIVATE_KEY }}
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Create release via ghrelease
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghrelease@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
             with-repo \
               --repo="${{ github.repository }}" \

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 jobs:
   check:
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -148,7 +148,7 @@ jobs:
           path: build/
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: write
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 jobs:
   check:
     runs-on: depot-ubuntu-24.04
@@ -69,14 +66,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Build and upload Linux nightly artifacts to bucket
         run: |
-          dagger call \
+          nix develop --command dagger call \
             release-nightly \
               --commit="${{ github.sha }}" \
               --post-hog-public-key="${{ secrets.POSTHOG_API_KEY }}" \
@@ -147,14 +145,15 @@ jobs:
           name: darwin-nightly
           path: build/
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Upload darwin artifacts to bucket
         run: |
-          dagger call \
+          nix develop --command dagger call \
             upload-darwin-artifacts \
               --access-key-id=env://BUCKET_ACCESS_KEY_ID \
               --binary=./build/darwin/arm64/mb \
@@ -194,7 +193,7 @@ jobs:
 
       - name: Upload all artifacts to GitHub release
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghrelease@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env:GH_TOKEN \
             with-repo --repo="${{ github.repository }}" \
             with-assets --assets=./build \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,14 +21,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check PR title conformance
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request \
@@ -48,14 +46,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check Linear magic word
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request-linear-magic-word \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 jobs:
   build-linux:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -103,7 +103,7 @@ jobs:
           path: build/
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 jobs:
   build-linux:
     name: Build & Upload Linux
@@ -18,14 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Build and upload Linux release artifacts to bucket
         run: |
-          dagger call \
+          nix develop --command dagger call \
             release-latest \
               --version="${{ github.event.release.tag_name }}" \
               --commit="${{ github.sha }}" \
@@ -71,7 +69,6 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 build/darwin/arm64/mb > build/darwin/arm64/mb.sha256
 
-
       - name: Upload darwin artifacts for gh release
         uses: actions/upload-artifact@v4
         with:
@@ -102,15 +99,16 @@ jobs:
           name: darwin-release
           path: build/
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Upload darwin artifacts to bucket
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          dagger call \
+          nix develop --command dagger call \
             upload-darwin-artifacts \
               --binary=./build/darwin/arm64/mb \
               --checksum=./build/darwin/arm64/mb.sha256 \
@@ -128,7 +126,7 @@ jobs:
 
       - name: Upload all artifacts to GitHub release
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghrelease \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghrelease@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
             with-repo --repo="${{ github.repository }}" \
             with-assets --assets=./build \

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "masterblaster",
-  "engineVersion": "v0.20.8",
+  "engineVersion": "v0.21.8",
   "sdk": {
     "source": "go"
   },

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776312396,
-        "narHash": "sha256-+kIlfrvisYdTgdix932MnQEKjq0yJsJL+vnG/I6QJ68=",
+        "lastModified": 1785344846,
+        "narHash": "sha256-E0v8IiF9sEWNw615Yae1RH8KtMuOOF+mcafu2m0kHyE=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "851584fd8093ab942b4aa833cdef53050b27279b",
+        "rev": "b35b2b5ab62ace3a3c1e779c497de1ad762a4aa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump Dagger engine to v0.21.8 (latest, 2026-07-29) and dagger/dagger-for-github to v8.4.1.